### PR TITLE
Add target

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ then create an instance and subscribe it to `ActiveSupport::Notifications` event
 
 ### Customising Targets
 
-Flatfoot default lookup is *app/views/**/*.html.erb'* rejecting all mailer views.
+Flatfoot default lookup is `app/views/**/*.html.erb` rejecting all mailer views.
 This will cover many apps but sometimes your project has different characteristics as:
   - using other view markup language as Haml;
   - using different folder structure (engines, for example), or;

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ then create an instance and subscribe it to `ActiveSupport::Notifications` event
 	  FLATFOOT.track_views(name, start, finish, id, payload) unless name.include?('!') 
     end
 
+### Customising Targets
+
+Flatfoot default lookup is *app/views/**/*.html.erb'* rejecting all mailer views.
+This will cover many apps but sometimes your project has different characteristics as:
+  - using other view markup language as Haml;
+  - using different folder structure (engines, for example), or;
+  - you want to analyze parts of your app (/admin, for example).
+
+The only change you need in your initialize is define your target during tracker
+initialization as example below:
+
+```ruby
+target = Dir.glob("app/views/admin/**/*.html.haml").reject do |file|
+  file.match(/(_mailer)/)
+end
+FLATFOOT = Flatfoot::Tracker.new(Redis.new, target)
+```
+
 Start up your app and then in console you can check used views or unused views
 
 	FLATFOOT.used_views

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ initialization as example below:
 target = Dir.glob("app/views/admin/**/*.html.haml").reject do |file|
   file.match(/(_mailer)/)
 end
-FLATFOOT = Flatfoot::Tracker.new(Redis.new, target)
+FLATFOOT = Flatfoot::Tracker.new(Redis.new, options: { target: target })
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -30,24 +30,6 @@ then create an instance and subscribe it to `ActiveSupport::Notifications` event
 	  FLATFOOT.track_views(name, start, finish, id, payload) unless name.include?('!') 
     end
 
-### Customising Targets
-
-Flatfoot default lookup is `app/views/**/*.html.erb` rejecting all mailer views.
-This will cover many apps but sometimes your project has different characteristics as:
-  - using other view markup language as Haml;
-  - using different folder structure (engines, for example), or;
-  - you want to analyze parts of your app (/admin, for example).
-
-The only change you need in your initialize is define your target during tracker
-initialization as example below:
-
-```ruby
-target = Dir.glob("app/views/admin/**/*.html.haml").reject do |file|
-  file.match(/(_mailer)/)
-end
-FLATFOOT = Flatfoot::Tracker.new(Redis.new, target)
-```
-
 Start up your app and then in console you can check used views or unused views
 
 	FLATFOOT.used_views
@@ -69,6 +51,24 @@ Then you should have tasks to help view the flatfoot data
     rake flatfoot:reset   # reset tracked views
     rake flatfoot:unused  # report unused views
     rake flatfoot:used    # report used views
+
+### Customising Targets
+
+Flatfoot default lookup is `app/views/**/*.html.erb` rejecting all mailer views.
+This will cover many apps but sometimes your project has different characteristics as:
+  - using other view markup language as Haml;
+  - using different folder structure (engines, for example), or;
+  - you want to analyze parts of your app (/admin, for example).
+
+The only change you need in your initialize is define your target during tracker
+initialization as example below:
+
+```ruby
+target = Dir.glob("app/views/admin/**/*.html.haml").reject do |file|
+  file.match(/(_mailer)/)
+end
+FLATFOOT = Flatfoot::Tracker.new(Redis.new, target)
+```
 
 ## Contributing
 

--- a/lib/flatfoot.rb
+++ b/lib/flatfoot.rb
@@ -8,9 +8,9 @@ module Flatfoot
     DEFAULT_TARGET = Dir.glob('app/views/**/*.html.erb').reject{ |file| file.match(/(_mailer)/) }
     attr_accessor :store, :target, :logged_views, :roots
 
-    def initialize(store, target = DEFAULT_TARGET, options = {})
+    def initialize(store, options = {})
       @store = store
-      @target = target
+      @target = options[:target] || DEFAULT_TARGET
       @logged_views = []
       @roots = options.fetch(:roots){ "#{Rails.root.to_s}/" }.split(',')
     end

--- a/lib/flatfoot.rb
+++ b/lib/flatfoot.rb
@@ -2,7 +2,7 @@ require "flatfoot/version"
 require 'timeout'
 
 module Flatfoot
-  
+
   class Tracker
 
     DEFAULT_TARGET = Dir.glob('app/views/**/*.html.erb').reject{ |file| file.match(/(_mailer)/) }
@@ -14,7 +14,7 @@ module Flatfoot
       @logged_views = []
       @roots = options.fetch(:roots){ "#{Rails.root.to_s}/" }.split(',')
     end
-    
+
     def track_views(name, start, finish, id, payload)
       begin
         if file = payload[:identifier]
@@ -44,11 +44,11 @@ module Flatfoot
       views = store.smembers(tracker_key)
       normalized_views = []
       views.each do |view|
-             roots.each do |root|
-                    view = view.gsub(/#{root}/,'')
-                  end
-             normalized_views << view
-           end
+        roots.each do |root|
+          view = view.gsub(/#{root}/,'')
+        end
+        normalized_views << view
+      end
       normalized_views
     end
 

--- a/lib/flatfoot.rb
+++ b/lib/flatfoot.rb
@@ -5,10 +5,12 @@ module Flatfoot
   
   class Tracker
 
-    attr_accessor :store, :logged_views, :roots
+    DEFAULT_TARGET = Dir.glob('app/views/**/*.html.erb').reject{ |file| file.match(/(_mailer)/) }
+    attr_accessor :store, :target, :logged_views, :roots
 
-    def initialize(store, options = {})
+    def initialize(store, target = DEFAULT_TARGET, options = {})
       @store = store
+      @target = target
       @logged_views = []
       @roots = options.fetch(:roots){ "#{Rails.root.to_s}/" }.split(',')
     end
@@ -51,9 +53,8 @@ module Flatfoot
     end
 
     def unused_views
-      all_views = Dir.glob('app/views/**/*.html.erb').reject{|file| file.match(/(_mailer)/)}
       recently_used_views = used_views
-      all_views = all_views.reject{ |view| recently_used_views.include?(view) }
+      all_views = target.reject{ |view| recently_used_views.include?(view) }
       # since layouts don't include format we count them used if they match with ANY formats
       all_views = all_views.reject{ |view| view.match(/\/layouts\//) && recently_used_views.any?{|used_view| view.include?(used_view)} }
     end

--- a/test/unit/flatfoot_test.rb
+++ b/test/unit/flatfoot_test.rb
@@ -6,6 +6,7 @@ class ReporterTest < Test::Unit::TestCase
     tracker = Flatfoot::Tracker.new("store", {:roots => 'dir'})
     assert_equal 'dir', tracker.roots.first
     assert_equal 'store', tracker.store
+    assert_equal [], tracker.target
     assert_equal [], tracker.logged_views
   end
 
@@ -34,8 +35,8 @@ class ReporterTest < Test::Unit::TestCase
 
   should "report unused partials" do
     store = fake_store
-    Dir.expects(:glob).returns(['file', 'not_used'])
-    tracker = Flatfoot::Tracker.new(store, {:roots => 'dir'})
+    target = ['file', 'not_used']
+    tracker = Flatfoot::Tracker.new(store, {:roots => 'dir', :target => target})
     tracker.track_views('name', 'start', 'finish', 'id', {:identifier => 'file'})
     assert_equal ['not_used'], tracker.unused_views
   end


### PR DESCRIPTION
Adds the ability to define a target instead of using the default one. Useful for projects that are structured in a different way or use different view markup languages.
